### PR TITLE
add working test for new POST visit method in 1.7.0

### DIFF
--- a/lib/nomis/api.rb
+++ b/lib/nomis/api.rb
@@ -1,0 +1,4 @@
+require_relative 'api/auth_token'
+require_relative 'api/get'
+require_relative 'api/parsed_response'
+require_relative 'api/post'

--- a/lib/nomis/api/get.rb
+++ b/lib/nomis/api/get.rb
@@ -10,7 +10,7 @@ module NOMIS
     # Convenience wrapper around an API call
     # Manages defaulting of params from env vars,
     # and parsing the returned JSON
-    class Request
+    class Get
       attr_accessor :params, :auth_token, :base_url, :path
 
       def initialize(opts={})

--- a/lib/nomis/api/post.rb
+++ b/lib/nomis/api/post.rb
@@ -1,0 +1,56 @@
+require 'uri'
+require 'net/http'
+require 'pp'
+
+require 'nomis/api/auth_token'
+require 'nomis/api/parsed_response'
+
+module NOMIS
+  module API
+    # Convenience wrapper around an API call
+    # Manages defaulting of params from env vars,
+    # and parsing the returned JSON
+    class Post
+      attr_accessor :params, :auth_token, :base_url, :path
+
+      def initialize(opts={})
+        self.auth_token = opts[:auth_token] || default_auth_token(opts)
+        self.base_url   = opts[:base_url] || ENV['NOMIS_API_BASE_URL']
+        self.params = opts[:params]
+        self.path = opts[:path]
+      end
+
+      def execute
+        uri = URI.join(base_url, path)
+
+        req = Net::HTTP::Post.new(uri)
+        req['Authorization'] = auth_token
+        req['Accept'] = 'application/json, */*'
+        req['Content-type'] = 'application/json'
+
+        ParsedResponse.new(post_response(req))
+      end
+
+      protected
+
+      def default_auth_token(params={})
+        ENV['NOMIS_API_AUTH_TOKEN'] || NOMIS::API::AuthToken.new(params).bearer_token
+      end
+
+
+      def post_response(req)
+        http = Net::HTTP.new(req.uri.hostname, req.uri.port)
+        http.use_ssl = (req.uri.scheme == 'https')
+        req.body = params.to_json
+        http.request(req)
+      end
+
+      def stringify_hash(data)
+        h={}
+        data.each{|k,v| h[k.to_s] = v }
+        h
+      end
+
+    end
+  end
+end

--- a/spec/1.4/slots_not_inclusive_bug_spec.rb
+++ b/spec/1.4/slots_not_inclusive_bug_spec.rb
@@ -22,7 +22,7 @@ describe 'prison slots' do
         let(:end_date){ start_date }
 
         describe 'the response' do
-          let(:response){ NOMIS::API::Request.new(path: url, params: params).execute }
+          let(:response){ NOMIS::API::Get.new(path: url, params: params).execute }
 
           describe 'status' do
             it 'should be 200' do

--- a/spec/1.6/offender_contact_list_spec.rb
+++ b/spec/1.6/offender_contact_list_spec.rb
@@ -13,7 +13,7 @@ describe 'offender contact list method' do
   end
 
   describe 'the response' do
-    let(:response){ NOMIS::API::Request.new(path: url, params: params).execute }
+    let(:response){ NOMIS::API::Get.new(path: url, params: params).execute }
 
     describe 'status' do
       it 'should be 200' do

--- a/spec/1.6/visit_unavailability_spec.rb
+++ b/spec/1.6/visit_unavailability_spec.rb
@@ -20,7 +20,7 @@ describe 'visit unavailability method' do
         let(:dates){ [Time.now + 86400] }
 
         describe 'the response' do
-          let(:response){ NOMIS::API::Request.new(path: url, params: params).execute }
+          let(:response){ NOMIS::API::Get.new(path: url, params: params).execute }
 
           describe 'status' do
             it 'should be 200' do

--- a/spec/1.7/post_visit_spec.rb
+++ b/spec/1.7/post_visit_spec.rb
@@ -1,0 +1,42 @@
+require 'app_helper'
+
+describe 'POST visit' do
+  let(:url){ "offenders/#{offender_id}/visits/booking" }
+  let(:offender_id){ ENV['NOMIS_API_OFFENDER_ID'] }
+
+    # Bomb out if no offender_id is given - we need to know a valid
+    # identifier for lots of methods, and there is no way of retrieving
+    # one without knowing more corroborating details (by design)
+    it 'has the required environment variables set' do
+      expect(offender_id).to_not be_nil, "You must supply a valid NOMIS_API_OFFENDER_ID environment variable"
+    end
+
+  context 'given a lead_contact and a slot' do
+    let(:params){ {lead_contact: lead_contact, slot: slot} }
+
+    # to avoid creating actual visits when testing against prod,
+    # we're sending parameters we KNOW are invalid, and testing 
+    # that the error we get back is 400 Bad Request
+    # (not 404, which would indicate either the method or the offender
+    #  is not there)
+    # TODO: figure out a more resilient yet still non-invasive test
+    # ...could we get a test offender set up in a ghost prison?
+    context 'that we know are invalid' do
+      let(:lead_contact){ 0 }
+      # 86400 seconds in a day - so this time yesterday
+      let(:slot){ (Time.now - 86400).strftime("%Y-%m-%dT12:00/12:45") }
+
+      describe 'the response' do
+        let(:response){ NOMIS::API::Post.new(path: url, params: params).execute }
+
+        describe 'status' do
+          
+          it 'should be 400' do
+            expect( response.status ).to eq("400")
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/app_helper.rb
+++ b/spec/app_helper.rb
@@ -3,5 +3,4 @@ require 'byebug'
 
 $: << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib/'))
 
-require 'nomis/api/request'
-require 'nomis/api/parsed_response'
+require 'nomis/api'


### PR DESCRIPTION
The test is working, although not ideal. To allow the tests to be run against all environments including prod, they need to be non-invasive, yet we need to test the method which lets us create a new visit.

So, we test the existence of the POST visit method by providing parameters which we know to be invalid (e.g. lead_contact_id: 0, slot: this time yesterday) and check that the error message we get back in the response is 400 Bad Request, rather than any other error (if the method was not deployed, it would be a 404 Not Found, for instance)

Need to work out a better way of doing this, as we will get more invasive/destructive methods to test in future